### PR TITLE
Improve formatting in QueueStatsOverview widget

### DIFF
--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -2,11 +2,13 @@
 
 namespace Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets;
 
+use Carbon\CarbonInterval;
 use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Number;
 
 class QueueStatsOverview extends BaseWidget
 {
@@ -26,10 +28,14 @@ class QueueStatsOverview extends BaseWidget
             ->map(fn (string $queue): int => Queue::size($queue))
             ->sum();
 
+        $totalJobs = Number::format($aggregatedInfo->count ?? 0);
+
+        $executionTime = CarbonInterval::seconds($aggregatedInfo->total_time_elapsed ?? 0)->cascade()->forHumans(short: true, parts: 3);
+
         return [
-            Stat::make(__('filament-jobs-monitor::translations.total_jobs'), $aggregatedInfo->count ?? 0),
+            Stat::make(__('filament-jobs-monitor::translations.total_jobs'), $totalJobs),
             Stat::make(__('filament-jobs-monitor::translations.pending_jobs'), $queueSize),
-            Stat::make(__('filament-jobs-monitor::translations.execution_time'), ($aggregatedInfo->total_time_elapsed ?? 0).'s'),
+            Stat::make(__('filament-jobs-monitor::translations.execution_time'), $executionTime),
             Stat::make(__('filament-jobs-monitor::translations.average_time'), ceil((float) $aggregatedInfo->average_time_elapsed).'s' ?? 0),
         ];
     }


### PR DESCRIPTION

Updated the stat's widget to be more human-readable, it now looks like this:

![image](https://github.com/user-attachments/assets/c7000d0e-1ae3-4da8-9efa-62bca9fcf5b0)

Instead of this:

![image](https://github.com/user-attachments/assets/07158230-ae4f-4354-92ab-e07518c629af)



