### PR TITLE
Add Portuguese translations for job monitoring

### DIFF
--- a/resources/lang/pt_BR/translations.php
+++ b/resources/lang/pt_BR/translations.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'breadcrumb' => 'Monitor de Jobs em Fila',
+    'title' => 'Jobs em Fila',
+    'navigation_label' => 'Jobs',
+    'navigation_group' => 'Sistema',
+    'total_jobs' => 'Total de Jobs Executados',
+    'pending_jobs' => 'Jobs Pendentes',
+    'execution_time' => 'Tempo Total de Execução',
+    'average_time' => 'Tempo Médio de Execução',
+    'succeeded' => 'Com Sucesso',
+    'failed' => 'Falharam',
+    'running' => 'Em Execução',
+    'status' => 'Status',
+    'name' => 'Nome',
+    'queue' => 'Fila',
+    'progress' => 'Progresso',
+    'started_at' => 'Iniciado em',
+    'details' => 'Detalhes',
+    'attempts' => 'Tentativas',
+    'exception' => 'Exceção',
+];


### PR DESCRIPTION
This pull request introduces a new translation file in Brazilian Portuguese (`pt_BR`) for a job queue monitoring feature. The file defines various keys and their corresponding translations to support the localization of the feature.

### Localization improvements:

* [`resources/lang/pt_BR/translations.php`](diffhunk://#diff-b41e0a750c15432489e265a2e1ce646c175077810dcf03fabd067d2d8374c570R1-R23): Added a new translation file with keys such as `breadcrumb`, `title`, `navigation_label`, and others, along with their Brazilian Portuguese translations to provide localization for the job queue monitoring interface.