### PR TITLE
fix: improve localized resource labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ return [
     'resources' => [
         'enabled' => true,
         'label' => 'filament-jobs-monitor::translations.model_label',
-        'plural_label' => 'filament-jobs-monitor::translations.navigation_label',
+        'plural_label' => 'filament-jobs-monitor::translations.plural_model_label',
         'navigation_group' => 'filament-jobs-monitor::translations.navigation_group',
         'navigation_icon' => 'heroicon-o-cpu-chip',
         'navigation_sort' => null,

--- a/config/filament-jobs-monitor.php
+++ b/config/filament-jobs-monitor.php
@@ -9,7 +9,7 @@ return [
     'resources' => [
         'enabled' => true,
         'label' => 'filament-jobs-monitor::translations.model_label',
-        'plural_label' => 'filament-jobs-monitor::translations.navigation_label',
+        'plural_label' => 'filament-jobs-monitor::translations.plural_model_label',
         'navigation_group' => 'filament-jobs-monitor::translations.navigation_group',
         'navigation_icon' => 'heroicon-o-cpu-chip',
         'navigation_sort' => null,

--- a/resources/lang/ar/translations.php
+++ b/resources/lang/ar/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'مراقب المهام في قائمة الانتظار',
     'title' => 'المهام المجدولة',
+    'plural_model_label' => 'المهام',
     'navigation_label' => 'المهام',
     'navigation_group' => 'الإعدادات',
     'total_jobs' => 'عدد المهام المنفذة',

--- a/resources/lang/cs/translations.php
+++ b/resources/lang/cs/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Monitor úloh ve frontě',
     'title' => 'Úlohy ve frontě',
+    'plural_model_label' => 'Úlohy',
     'navigation_label' => 'Úlohy',
     'navigation_group' => 'Nastavení',
     'total_jobs' => 'Celkový počet zpracovaných úloh',

--- a/resources/lang/de/translations.php
+++ b/resources/lang/de/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Hintergrundprozesse',
     'title' => 'Hintergrundprozesse',
+    'plural_model_label' => 'Hintergrundprozesse',
     'navigation_label' => 'Hintergrundprozesse',
     'navigation_group' => 'Einstellungen',
     'total_jobs' => 'Ausgeführte Prozesse',

--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -4,6 +4,7 @@ return [
     'breadcrumb' => 'Queued Jobs Monitor',
     'title' => 'Queued Jobs',
     'model_label' => 'Job',
+    'plural_model_label' => 'Jobs',
     'navigation_label' => 'Jobs',
     'navigation_group' => 'Settings',
     'total_jobs' => 'Total Jobs Executed',

--- a/resources/lang/es/translations.php
+++ b/resources/lang/es/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Monitor de Trabajos En Cola',
     'title' => 'Trabajos En Cola',
+    'plural_model_label' => 'Trabajos',
     'navigation_label' => 'Trabajos',
     'navigation_group' => 'Ajustes',
     'total_jobs' => 'Total Trabajos Ejecutados',

--- a/resources/lang/fa/translations.php
+++ b/resources/lang/fa/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'مانیتور صف‌وظایف',
     'title' => 'وظایف در صف',
+    'plural_model_label' => 'وظایف',
     'navigation_label' => 'وظایف',
     'navigation_group' => 'تنظیمات',
     'total_jobs' => 'مجموع وظایف اجرا شده',

--- a/resources/lang/fr/translations.php
+++ b/resources/lang/fr/translations.php
@@ -4,6 +4,7 @@ return [
     'breadcrumb' => 'Monitor de Jobs En File',
     'title' => 'Jobs',
     'model_label' => 'Job',
+    'plural_model_label' => 'Jobs',
     'navigation_label' => 'Jobs',
     'navigation_group' => 'Paramètres',
     'total_jobs' => 'Total Jobs Exécutés',

--- a/resources/lang/he/translations.php
+++ b/resources/lang/he/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'ניטור עבודות בתור',
     'title' => 'עבודות בתור',
+    'plural_model_label' => 'עבודות',
     'navigation_label' => 'עבודות',
     'navigation_group' => 'הגדרות',
     'total_jobs' => 'סך כל העבודות שבוצעו',

--- a/resources/lang/it/translations.php
+++ b/resources/lang/it/translations.php
@@ -7,6 +7,7 @@ return [
     'failed' => 'Fallito',
     'name' => 'Nome',
     'navigation_group' => 'Impostazioni',
+    'plural_model_label' => 'Lavori',
     'navigation_label' => 'Lavori',
     'pending_jobs' => 'Lavori in sospeso',
     'progress' => 'Progresso',

--- a/resources/lang/nl/translations.php
+++ b/resources/lang/nl/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Achtergrondtaken Monitor',
     'title' => 'Achtergrondtaken',
+    'plural_model_label' => 'Achtergrondtaken',
     'navigation_label' => 'Achtergrondtaken',
     'navigation_group' => 'Instellingen',
     'total_jobs' => 'Totaal aantal verwerkte taken',

--- a/resources/lang/pl/translations.php
+++ b/resources/lang/pl/translations.php
@@ -4,6 +4,7 @@ return [
     'breadcrumb' => 'Kolejka zadań',
     'title' => 'Kolejka zadań',
     'model_label' => 'Zadanie',
+    'plural_model_label' => 'Zadania',
     'navigation_label' => 'Zadania',
     'navigation_group' => 'Ustawienia',
     'total_jobs' => 'Łączna liczba wykonanych zadań',

--- a/resources/lang/pt_BR/translations.php
+++ b/resources/lang/pt_BR/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Monitor de Jobs em Fila',
     'title' => 'Jobs em Fila',
+    'plural_model_label' => 'Jobs',
     'navigation_label' => 'Jobs',
     'navigation_group' => 'Configurações',
     'total_jobs' => 'Total de Jobs Executados',

--- a/resources/lang/ru/translations.php
+++ b/resources/lang/ru/translations.php
@@ -4,6 +4,7 @@ return [
     'breadcrumb' => 'Мониторинг заданий в очереди',
     'title' => 'Задания в очереди',
     'model_label' => 'Задание',
+    'plural_model_label' => 'Задания',
     'navigation_label' => 'Задания',
     'navigation_group' => 'Настройки',
     'total_jobs' => 'Всего выполнено заданий',

--- a/resources/lang/sk/translations.php
+++ b/resources/lang/sk/translations.php
@@ -3,6 +3,7 @@
 return [
     'breadcrumb' => 'Monitor frontových úloh',
     'title' => 'Frontové úlohy',
+    'plural_model_label' => 'Úlohy',
     'navigation_label' => 'Úlohy',
     'navigation_group' => 'Nastavenia',
     'total_jobs' => 'Celkový počet vykonaných úloh',

--- a/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
+++ b/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
@@ -31,6 +31,11 @@ class ListQueueMonitors extends ListRecords
         return __('filament-jobs-monitor::translations.title');
     }
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament-jobs-monitor::translations.queued_jobs');
+    }
+
     public function getTabs(): array
     {
         return [

--- a/tests/Feature/PluginLabelTest.php
+++ b/tests/Feature/PluginLabelTest.php
@@ -19,7 +19,9 @@ function registerJsonTranslation(string $key, string $value, string $locale = 'e
 it('translates the namespaced keys the shipped config points at', function () {
     $plugin = FilamentJobsMonitorPlugin::make();
 
-    expect($plugin->getLabel())->toBe('Job')
+    expect(config('filament-jobs-monitor.resources.plural_label'))
+        ->toBe('filament-jobs-monitor::translations.plural_model_label')
+        ->and($plugin->getLabel())->toBe('Job')
         ->and($plugin->getPluralLabel())->toBe('Jobs')
         ->and($plugin->getNavigationGroup())->toBe('Settings');
 });

--- a/tests/Feature/TranslationParityTest.php
+++ b/tests/Feature/TranslationParityTest.php
@@ -6,8 +6,8 @@
  * visible, and `it('only lists genuinely incomplete locales …')` fails as soon
  * as one of them catches up, which forces it to be removed from this list.
  *
- * Key counts at the time of writing (out of 109):
- *   ar 61, cs 18, de 61, es 19, fa 17, he 61, it 19, nl 17, pt_BR 19, sk 19
+ * Key counts at the time of writing (out of 110):
+ *   ar 62, cs 19, de 62, es 20, fa 18, he 62, it 20, nl 18, pt_BR 20, sk 20
  *
  * `ar` additionally drops the `:count` placeholder in
  * `bulk_retry_partial_description`; that is covered by the placeholder


### PR DESCRIPTION
## Summary

- Localize the `ListQueueMonitors` sub-navigation label using the existing `queued_jobs` translation key.
- Add a dedicated `plural_model_label` key instead of reusing `navigation_label`.
- Add `plural_model_label` to all supported locales to avoid English fallbacks.
- Update the published configuration example and translation tests.

## Why

Filament treats the plural model label and navigation label as separate concepts, even though their values currently coincide.

The explicit page navigation label also prevents Filament from generating the English `List Queue Monitors` label from the page class name.

## Testing

- Ran `vendor/bin/pest --no-coverage`.
- 48 tests passed.
- 10 known incomplete-locale tests were skipped as expected.