### PR TITLE
chore: pin GitHub Actions to SHAs and widen Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
@@ -10,3 +10,19 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    # Actions are pinned to a commit SHA, so let a release settle before
+    # adopting it rather than tracking every freshly published tag.
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -16,14 +16,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, fileinfo


### PR DESCRIPTION
The plugin directory's package health scan reports **Security 64/100** (overall 80/100), with three checks failing. This fixes all three.

| Check | Before | Cause |
|---|---|---|
| GitHub Actions pinned to SHA | ❌ | every `uses:` referenced a mutable tag |
| Dependabot or Renovate configured | ⚠️ | `package-lock.json` committed, npm ecosystem not covered |
| Dependency update cooldown configured | ❌ | no `cooldown` in `.github/dependabot.yml` |

### Pinned actions

Each `uses:` now carries a full commit SHA with the resolved version as a trailing comment, so a retagged or compromised release cannot change what runs in CI. Dependabot updates both the SHA and the comment.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v7` | `3d3c42e` # v7.0.1 |
| `shivammathur/setup-php` | `@v2` | `f3e473d` # 2.37.2 |
| `aglipanci/laravel-pint-action` | `@2.6` | `36de00d` # 2.6 |
| `stefanzweifel/git-auto-commit-action` | `@v7` | `4a55954` # v7.2.0 |
| `dependabot/fetch-metadata` | `@v3.1.0` | `25dd0e3` # v3.1.0 |

Every SHA was resolved from the tag it replaces, so this is a no-op for behaviour.

### Dependabot

- **npm** ecosystem added — `package-lock.json` is committed and tracked in git, but nothing was updating it.
- **cooldown** on both ecosystems: a freshly published release has to settle before it is proposed. `default-days: 7` for actions; for npm, 30 days on major, 7 on minor, 3 on patch. That delay is the window in which a compromised release usually gets caught and yanked.

No source change — CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)